### PR TITLE
Fix become issue with include tasks

### DIFF
--- a/roles/system_print/tasks/main.yml
+++ b/roles/system_print/tasks/main.yml
@@ -30,5 +30,6 @@
 - name: import task file to install and configure cups-pdf
   ansible.builtin.include_tasks:
     file: cups_pdf.yml
-  become: true
+    apply:
+      become: true
   when: system_print_cups_pdf_config is defined


### PR DESCRIPTION
fix: become statement couldn't be applied to included cups-pdf tasks file